### PR TITLE
Decouple instrumentation from user processor

### DIFF
--- a/app/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller.rb
@@ -18,11 +18,14 @@ module Decidim
             enforce_permission_to :create, :authorization
 
             @userslist = params[:userslist]
-            @processor = UserProcessor.new(current_organization, current_user, session)
+
+            @processor = UserProcessor.new(current_organization, current_user, session, instrumenter)
             @processor.emails = parser_class.new(@userslist).to_h
             @processor.authorization_handler = current_authorization_handler
+
             @stats = UserStats.new(current_organization)
             @stats.authorization_handler = @processor.authorization_handler
+
             register_users
             authorize_users
             revoke_users
@@ -34,13 +37,17 @@ module Decidim
 
           private
 
+          def instrumenter
+            @instrumenter ||= Instrumenter.new(current_user)
+          end
+
           def register_users
             return unless params[:register]
 
             @processor.register_users
             flash[:warning] = t(".registered", count: @processor.emails.count,
-                                               registered: @processor.processed[:registered].count,
-                                               errors: @processor.errors[:registered].count)
+                                               registered: instrumenter.processed[:registered].count,
+                                               errors: instrumenter.errors[:registered].count)
           end
 
           def authorize_users
@@ -49,8 +56,8 @@ module Decidim
             @processor.authorize_users
             flash[:notice] = t(".authorized", handler: t("#{@processor.authorization_handler}.name", scope: "decidim.authorization_handlers"),
                                               count: @processor.emails.count,
-                                              authorized: @processor.processed[:authorized].count,
-                                              errors: @processor.errors[:authorized].count)
+                                              authorized: instrumenter.processed[:authorized].count,
+                                              errors: instrumenter.errors[:authorized].count)
           end
 
           def revoke_users
@@ -59,8 +66,8 @@ module Decidim
             @processor.revoke_users
             flash[:notice] = t(".revoked", handler: t("#{@processor.authorization_handler}.name", scope: "decidim.authorization_handlers"),
                                            count: @processor.emails.count,
-                                           revoked: @processor.processed[:revoked].count,
-                                           errors: @processor.errors[:revoked].count)
+                                           revoked: instrumenter.processed[:revoked].count,
+                                           errors: instrumenter.errors[:revoked].count)
           end
 
           def show_users_info

--- a/lib/decidim/direct_verifications/instrumenter.rb
+++ b/lib/decidim/direct_verifications/instrumenter.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    class Instrumenter
+      attr_reader :processed, :errors
+
+      def initialize(current_user)
+        @current_user = current_user
+        @errors = { registered: [], authorized: [], revoked: [] }
+        @processed = { registered: [], authorized: [], revoked: [] }
+      end
+
+      def track(event, email, user = nil)
+        if user
+          add_processed event, email
+          log_action user
+        else
+          add_error event, email
+        end
+      end
+
+      def add_error(type, email)
+        @errors[type] << email unless @errors[type].include? email
+      end
+
+      def add_processed(type, email)
+        @processed[type] << email unless @processed[type].include? email
+      end
+
+      private
+
+      attr_reader :current_user
+
+      def log_action(user)
+        Decidim.traceability.perform_action!(
+          "invite",
+          user,
+          current_user,
+          extra: {
+            invited_user_role: "participant",
+            invited_user_id: user.id
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/decidim/direct_verifications/authorize_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/authorize_user_spec.rb
@@ -15,7 +15,7 @@ module Decidim
           let(:user) { create(:user, organization: organization) }
           let(:email) { user.email }
           let(:session) { {} }
-          let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+          let(:instrumenter) { instance_double(Instrumenter, add_processed: true, add_error: true) }
 
           context "when passing the user name" do
             let(:data) { user.name }
@@ -108,7 +108,7 @@ module Decidim
           let(:email) { "em@mail.com" }
           let(:data) { "Andy" }
           let(:session) { {} }
-          let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+          let(:instrumenter) { instance_double(Instrumenter, add_processed: true, add_error: true) }
 
           it "tracks an error" do
             subject.call

--- a/spec/lib/decidim/direct_verifications/instrumenter_spec.rb
+++ b/spec/lib/decidim/direct_verifications/instrumenter_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module DirectVerifications
+    describe Instrumenter do
+      subject { described_class.new(current_user) }
+
+      let(:current_user) { build_stubbed(:user) }
+
+      shared_examples "an error event" do |type|
+        context "when the email does not exist" do
+          it "adds the email" do
+            subject.add_error(type, "email@example.com")
+            expect(subject.errors[type]).to contain_exactly("email@example.com")
+          end
+        end
+
+        context "when the email already exists" do
+          before { subject.add_error(type, "email@example.com") }
+
+          it "does not duplicate the email" do
+            subject.add_error(type, "email@example.com")
+            expect(subject.errors[type]).to contain_exactly("email@example.com")
+          end
+        end
+      end
+
+      shared_examples "a process event" do |type|
+        context "when the email does not exist" do
+          it "adds the email" do
+            subject.add_processed(type, "email@example.com")
+            expect(subject.processed[type]).to contain_exactly("email@example.com")
+          end
+        end
+
+        context "when the email already exists" do
+          before { subject.add_processed(type, "email@example.com") }
+
+          it "does not duplicate the email" do
+            subject.add_processed(type, "email@example.com")
+            expect(subject.processed[type]).to contain_exactly("email@example.com")
+          end
+        end
+      end
+
+      describe "#add_error" do
+        it_behaves_like "an error event", :registered
+        it_behaves_like "an error event", :authorized
+        it_behaves_like "an error event", :revoked
+
+        context "when the provided type does not exist" do
+          let(:type) { :fake }
+
+          it "raises due to NilClass" do
+            expect { subject.add_error(type, "email@example.com") }.to raise_error(NoMethodError)
+          end
+        end
+      end
+
+      describe "#add_processed" do
+        it_behaves_like "an error event", :registered
+        it_behaves_like "an error event", :authorized
+        it_behaves_like "an error event", :revoked
+
+        context "when the provided type does not exist" do
+          let(:type) { :fake }
+
+          it "raises due to NilClass" do
+            expect { subject.add_processed(type, "email@example.com") }.to raise_error(NoMethodError)
+          end
+        end
+      end
+
+      describe "#track" do
+        context "when a user is passed" do
+          let(:user) { build_stubbed(:user) }
+
+          before { allow(Decidim.traceability).to receive(:perform_action!) }
+
+          context "and the provided type exists" do
+            let(:type) { :registered }
+
+            it "adds the process event" do
+              subject.track(type, "email@example.com", user)
+              expect(subject.processed[type]).to contain_exactly("email@example.com")
+            end
+
+            it "logs the action" do
+              expect(Decidim.traceability).to receive(:perform_action!).with(
+                "invite",
+                user,
+                current_user,
+                extra: {
+                  invited_user_role: "participant",
+                  invited_user_id: user.id
+                }
+              )
+              subject.track(type, "email@example.com", user)
+            end
+          end
+
+          context "and the provided type does not exist" do
+            let(:type) { :fake }
+
+            it "raises due to NilClass" do
+              expect { subject.track(type, "email@example.com", user) }.to raise_error(NoMethodError)
+            end
+          end
+        end
+
+        context "when a user is not passed" do
+          context "and the provided type exists" do
+            let(:type) { :registered }
+
+            it "adds the error event" do
+              subject.track(type, "email@example.com")
+              expect(subject.errors[type]).to contain_exactly("email@example.com")
+            end
+          end
+
+          context "and the provided type does not exist" do
+            let(:type) { :fake }
+
+            it "raises due to NilClass" do
+              expect { subject.track(type, "email@example.com") }.to raise_error(NoMethodError)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/decidim/direct_verifications/register_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/register_user_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
       let(:user) { build(:user) }
       let(:organization) { build(:organization) }
-      let(:instrumenter) { instance_double(UserProcessor, track: true) }
+      let(:instrumenter) { instance_double(Instrumenter, track: true) }
 
       let(:email) { "em@il.com" }
       let(:name) { "Joni" }

--- a/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
       describe "#call" do
         let(:organization) { build(:organization) }
-        let(:instrumenter) { instance_double(UserProcessor, add_processed: true, add_error: true) }
+        let(:instrumenter) { instance_double(Instrumenter, add_processed: true, add_error: true) }
 
         context "when revoking existing users" do
           let(:user) { create(:user, organization: organization) }


### PR DESCRIPTION
Extracts an `Instrumenter` class out of `UserProcessor`. This a separate responsibility that deserves its own class and which hampers `UserProcessor` 's changeability. As a result, implementing async processing will be even easier.