### PR TITLE
Abstract instrumenter to not leak data structures

### DIFF
--- a/app/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller.rb
@@ -46,8 +46,8 @@ module Decidim
 
             @processor.register_users
             flash[:warning] = t(".registered", count: @processor.emails.count,
-                                               registered: instrumenter.processed[:registered].count,
-                                               errors: instrumenter.errors[:registered].count)
+                                               registered: instrumenter.processed_count(:registered),
+                                               errors: instrumenter.errors_count(:registered))
           end
 
           def authorize_users
@@ -56,8 +56,8 @@ module Decidim
             @processor.authorize_users
             flash[:notice] = t(".authorized", handler: t("#{@processor.authorization_handler}.name", scope: "decidim.authorization_handlers"),
                                               count: @processor.emails.count,
-                                              authorized: instrumenter.processed[:authorized].count,
-                                              errors: instrumenter.errors[:authorized].count)
+                                              authorized: instrumenter.processed_count(:authorized),
+                                              errors: instrumenter.errors_count(:authorized))
           end
 
           def revoke_users
@@ -66,8 +66,8 @@ module Decidim
             @processor.revoke_users
             flash[:notice] = t(".revoked", handler: t("#{@processor.authorization_handler}.name", scope: "decidim.authorization_handlers"),
                                            count: @processor.emails.count,
-                                           revoked: instrumenter.processed[:revoked].count,
-                                           errors: instrumenter.errors[:revoked].count)
+                                           revoked: instrumenter.processed_count(:revoked),
+                                           errors: instrumenter.errors_count(:revoked))
           end
 
           def show_users_info

--- a/lib/decidim/direct_verifications/instrumenter.rb
+++ b/lib/decidim/direct_verifications/instrumenter.rb
@@ -3,12 +3,18 @@
 module Decidim
   module DirectVerifications
     class Instrumenter
-      attr_reader :processed, :errors
-
       def initialize(current_user)
         @current_user = current_user
         @errors = { registered: [], authorized: [], revoked: [] }
         @processed = { registered: [], authorized: [], revoked: [] }
+      end
+
+      def processed_count(key)
+        processed[key].size
+      end
+
+      def errors_count(key)
+        errors[key].size
       end
 
       def track(event, email, user = nil)
@@ -30,7 +36,7 @@ module Decidim
 
       private
 
-      attr_reader :current_user
+      attr_reader :current_user, :processed, :errors
 
       def log_action(user)
         Decidim.traceability.perform_action!(

--- a/spec/lib/decidim/direct_verifications/instrumenter_spec.rb
+++ b/spec/lib/decidim/direct_verifications/instrumenter_spec.rb
@@ -13,7 +13,7 @@ module Decidim
         context "when the email does not exist" do
           it "adds the email" do
             subject.add_error(type, "email@example.com")
-            expect(subject.errors[type]).to contain_exactly("email@example.com")
+            expect(subject.errors_count(type)).to eq(1)
           end
         end
 
@@ -22,7 +22,7 @@ module Decidim
 
           it "does not duplicate the email" do
             subject.add_error(type, "email@example.com")
-            expect(subject.errors[type]).to contain_exactly("email@example.com")
+            expect(subject.errors_count(type)).to eq(1)
           end
         end
       end
@@ -31,7 +31,7 @@ module Decidim
         context "when the email does not exist" do
           it "adds the email" do
             subject.add_processed(type, "email@example.com")
-            expect(subject.processed[type]).to contain_exactly("email@example.com")
+            expect(subject.processed_count(type)).to eq(1)
           end
         end
 
@@ -40,7 +40,7 @@ module Decidim
 
           it "does not duplicate the email" do
             subject.add_processed(type, "email@example.com")
-            expect(subject.processed[type]).to contain_exactly("email@example.com")
+            expect(subject.processed_count(type)).to eq(1)
           end
         end
       end
@@ -84,7 +84,7 @@ module Decidim
 
             it "adds the process event" do
               subject.track(type, "email@example.com", user)
-              expect(subject.processed[type]).to contain_exactly("email@example.com")
+              expect(subject.processed_count(type)).to eq(1)
             end
 
             it "logs the action" do
@@ -116,7 +116,7 @@ module Decidim
 
             it "adds the error event" do
               subject.track(type, "email@example.com")
-              expect(subject.errors[type]).to contain_exactly("email@example.com")
+              expect(subject.errors_count(type)).to eq(1)
             end
           end
 

--- a/spec/lib/decidim/direct_verifications/user_processor_spec.rb
+++ b/spec/lib/decidim/direct_verifications/user_processor_spec.rb
@@ -41,8 +41,8 @@ module Decidim
           end
 
           it "has no errors" do
-            expect(instrumenter.processed[:registered].count).to eq(2)
-            expect(instrumenter.errors[:registered].count).to eq(0)
+            expect(instrumenter.processed_count(:registered)).to eq(2)
+            expect(instrumenter.errors_count(:registered)).to eq(0)
           end
         end
 
@@ -53,8 +53,8 @@ module Decidim
           end
 
           it "has no errors" do
-            expect(instrumenter.processed[:registered].count).to eq(1)
-            expect(instrumenter.errors[:registered].count).to eq(0)
+            expect(instrumenter.processed_count(:registered)).to eq(1)
+            expect(instrumenter.errors_count(:registered)).to eq(0)
           end
         end
       end
@@ -68,8 +68,8 @@ module Decidim
           it "has no errors" do
             subject.authorize_users
 
-            expect(instrumenter.processed[:authorized].count).to eq(1)
-            expect(instrumenter.errors[:authorized].count).to eq(0)
+            expect(instrumenter.processed_count(:authorized)).to eq(1)
+            expect(instrumenter.errors_count(:authorized)).to eq(0)
           end
         end
 
@@ -93,8 +93,8 @@ module Decidim
           it "has no errors" do
             subject.authorize_users
 
-            expect(instrumenter.processed[:authorized].count).to eq(1)
-            expect(instrumenter.errors[:authorized].count).to eq(0)
+            expect(instrumenter.processed_count(:authorized)).to eq(1)
+            expect(instrumenter.errors_count(:authorized)).to eq(0)
           end
         end
 
@@ -122,8 +122,8 @@ module Decidim
         it "has no errors" do
           subject.revoke_users
 
-          expect(instrumenter.processed[:revoked].count).to eq(1)
-          expect(instrumenter.errors[:revoked].count).to eq(0)
+          expect(instrumenter.processed_count(:revoked)).to eq(1)
+          expect(instrumenter.errors_count(:revoked)).to eq(0)
         end
       end
 
@@ -136,8 +136,8 @@ module Decidim
         it "has errors" do
           subject.revoke_users
 
-          expect(instrumenter.processed[:revoked].count).to eq(0)
-          expect(instrumenter.errors[:revoked].count).to eq(1)
+          expect(instrumenter.processed_count(:revoked)).to eq(0)
+          expect(instrumenter.errors_count(:revoked)).to eq(1)
         end
       end
     end


### PR DESCRIPTION
This more abstract public API will enable us to provide different implementations of instrumenter without having to touch its consumers.