### PR TITLE
Revoke users async

### DIFF
--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -9,21 +9,32 @@ module Decidim
           @file = form.file
           @organization = form.organization
           @user = form.user
+          @action = form.action
         end
 
         def call
           return broadcast(:invalid) unless form.valid?
 
-          register_users_async
+          case action
+          when :register
+            register_users_async
+          when :revoke
+            revoke_users_async
+          end
+
           broadcast(:ok)
         end
 
         private
 
-        attr_reader :form, :file, :organization, :user
+        attr_reader :form, :file, :organization, :user, :action
 
         def register_users_async
           RegisterUsersJob.perform_later(file.read, organization, user)
+        end
+
+        def revoke_users_async
+          RevokeUsersJob.perform_later(file.read, organization, user)
         end
       end
     end

--- a/app/jobs/decidim/direct_verifications/register_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/register_users_job.rb
@@ -33,7 +33,7 @@ module Decidim
       end
 
       def send_email_notification
-        ImportMailer.finished_registration(current_user, instrumenter).deliver_now
+        ImportMailer.finished_processing(current_user, instrumenter, :registered).deliver_now
       end
     end
   end

--- a/app/jobs/decidim/direct_verifications/revoke_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/revoke_users_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    class RevokeUsersJob < ApplicationJob
+      queue_as :default
+
+      def perform(userslist, organization, current_user)
+        @emails = Verification::MetadataParser.new(userslist).to_h
+        @organization = organization
+        @current_user = current_user
+        @instrumenter = Instrumenter.new(current_user)
+
+        revoke_users
+        send_email_notification
+      end
+
+      private
+
+      attr_reader :emails, :organization, :current_user, :instrumenter
+
+      def revoke_users
+        emails.each do |email, _name|
+          RevokeUser.new(email, organization, instrumenter).call
+        end
+      end
+
+      def send_email_notification
+        ImportMailer.finished_processing(current_user, instrumenter, :revoked).deliver_now
+      end
+    end
+  end
+end

--- a/app/mailers/decidim/direct_verifications/import_mailer.rb
+++ b/app/mailers/decidim/direct_verifications/import_mailer.rb
@@ -3,24 +3,21 @@
 module Decidim
   module DirectVerifications
     class ImportMailer < Decidim::Admin::ApplicationMailer
-      Stats = Struct.new(:count, :registered, :errors, keyword_init: true)
-
       include LocalisedMailer
 
       layout "decidim/mailer"
 
-      def finished_registration(user, instrumenter)
+      I18N_SCOPE = "decidim.direct_verifications.verification.admin.imports.mailer"
+
+      def finished_processing(user, instrumenter, type)
+        @stats = Stats.from(instrumenter, type)
         @organization = user.organization
-        @stats = Stats.new(
-          count: instrumenter.emails_count(:registered),
-          registered: instrumenter.processed_count(:registered),
-          errors: instrumenter.errors_count(:registered)
-        )
+        @i18n_key = "#{I18N_SCOPE}.#{type}"
 
         with_user(user) do
           mail(
             to: user.email,
-            subject: I18n.t("decidim.direct_verifications.verification.admin.imports.mailer.subject")
+            subject: I18n.t("#{I18N_SCOPE}.subject")
           )
         end
       end

--- a/app/mailers/decidim/direct_verifications/stats.rb
+++ b/app/mailers/decidim/direct_verifications/stats.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    class Stats
+      attr_reader :count, :successful, :errors
+
+      def self.from(instrumenter, type)
+        new(
+          count: instrumenter.emails_count(type),
+          successful: instrumenter.processed_count(type),
+          errors: instrumenter.errors_count(type)
+        )
+      end
+
+      def initialize(count:, successful:, errors:)
+        @count = count
+        @successful = successful
+        @errors = errors
+      end
+    end
+  end
+end

--- a/app/views/decidim/direct_verifications/import_mailer/finished_processing.html.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_processing.html.erb
@@ -1,0 +1,7 @@
+<p><%= t(
+  @i18n_key,
+  count: @stats.count,
+  successful: @stats.successful,
+  errors: @stats.errors,
+  handler: :direct_verifications
+) %></p>

--- a/app/views/decidim/direct_verifications/import_mailer/finished_processing.text.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_processing.text.erb
@@ -1,0 +1,7 @@
+<%= t(
+  @i18n_key,
+  count: @stats.count,
+  successful: @stats.successful,
+  errors: @stats.errors,
+  handler: :direct_verifications
+) %>

--- a/app/views/decidim/direct_verifications/import_mailer/finished_registration.html.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_registration.html.erb
@@ -1,1 +1,0 @@
-<p><%= t("decidim.direct_verifications.verification.admin.direct_verifications.create.registered", count: @stats.count, registered: @stats.registered, errors: @stats.errors) %></p>

--- a/app/views/decidim/direct_verifications/import_mailer/finished_registration.text.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_registration.text.erb
@@ -1,1 +1,0 @@
-<%= t("decidim.direct_verifications.verification.admin.direct_verifications.create.registered", count: @stats.count, registered: @stats.registered, errors: @stats.errors) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,14 @@ en:
               error: There was an error importing the file
             mailer:
               subject: Users processed
+              authorized: "%{successful} users have been successfully verified using
+                [%{handler}] (%{count} detected, %{errors} errors)"
+              info: "%{count} users detected, of which %{registered} are registered,
+                %{authorized} authorized using [%{handler}] (%{unconfirmed} unconfirmed)"
+              registered: "%{successful} users have been successfully registered (%{count}
+                detected, %{errors} errors) "
+              revoked: Verification from %{successful} users have been revoked using
+                [%{handler}] (%{count} detected, %{errors} errors)
           authorizations:
             index:
               created_at: Created at

--- a/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
@@ -4,11 +4,14 @@ require "spec_helper"
 
 module Decidim
   module DirectVerifications
-    describe RegisterUsersJob, type: :job do
+    describe RevokeUsersJob, type: :job do
       let(:userslist) { "Name,Email,Type\r\n\"\",brandy@example.com,consumer" }
       let(:organization) { create(:organization) }
-      let!(:current_user) { create(:user, organization: organization) }
+      let(:current_user) { create(:user, organization: organization) }
       let(:mailer) { double(:mailer, deliver_now: true) }
+
+      let(:user) { create(:user, organization: organization, email: "brandy@example.com") }
+      let!(:authorization) { create(:authorization, :granted, user: user, name: :direct_verifications) }
 
       around do |example|
         perform_enqueued_jobs { example.run }
@@ -17,24 +20,13 @@ module Decidim
       before do
         allow(ImportMailer)
           .to receive(:finished_processing)
-          .with(current_user, kind_of(Instrumenter), :registered)
+          .with(current_user, kind_of(Instrumenter), :revoked)
           .and_return(mailer)
       end
 
-      it "creates the user" do
-        expect { described_class.perform_later(userslist, organization, current_user) }
-          .to change(Decidim::User, :count).from(1).to(2)
-
-        user = Decidim::User.find_by(email: "brandy@example.com")
-        expect(user.name).to eq("brandy")
-      end
-
-      it "does not authorize the user" do
+      it "deletes the user authorization" do
         described_class.perform_later(userslist, organization, current_user)
-
-        user = Decidim::User.find_by(email: "brandy@example.com")
-        authorization = Decidim::Authorization.find_by(decidim_user_id: user.id)
-        expect(authorization).to be_nil
+        expect(Decidim::Authorization.find_by(id: authorization.id)).to be_nil
       end
 
       it "notifies the result by email" do

--- a/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
+++ b/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
@@ -7,64 +7,72 @@ module Decidim
     describe ImportMailer, type: :mailer do
       let(:user) { build(:user) }
 
-      describe "#finished_registration" do
-        subject(:mail) { described_class.finished_registration(user, instrumenter) }
+      describe "#finished_processing" do
+        subject(:mail) { described_class.finished_processing(user, instrumenter, type) }
 
-        context "when the import had no errors" do
-          let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 1, errors_count: 0) }
+        let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 1, errors_count: 0) }
+        let(:type) { :registered }
 
-          it "sends the email to the passed user" do
-            expect(mail.to).to eq([user.email])
+        it "sends the email to the passed user" do
+          expect(mail.to).to eq([user.email])
+        end
+
+        it "renders the subject" do
+          expect(mail.subject).to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.mailer.subject"))
+        end
+
+        it "localizes the subject" do
+          user.locale = "ca"
+          expect(I18n).to receive(:with_locale).with("ca")
+
+          mail.body
+        end
+
+        it "sets the organization" do
+          expect(mail.body.encoded).to include(user.organization.name)
+        end
+
+        context "when the type is :registered" do
+          let(:type) { :registered }
+
+          context "when the import had no errors" do
+            it "shows the number of errors" do
+              expect(mail.body.encoded).to include(
+                "1 users have been successfully registered (1 detected, 0 errors)"
+              )
+            end
           end
 
-          it "renders the subject" do
-            expect(mail.subject).to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.mailer.subject"))
-          end
+          context "when the import had errors" do
+            let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 0, errors_count: 1) }
 
-          it "localizes the subject" do
-            user.locale = "ca"
-            expect(I18n).to receive(:with_locale).with("ca")
-
-            mail.body
-          end
-
-          it "renders the body" do
-            expect(mail.body.encoded).to include(
-              "1 users have been successfully registered (1 detected, 0 errors)"
-            )
-          end
-
-          it "sets the organization" do
-            expect(mail.body.encoded).to include(user.organization.name)
+            it "shows the number of errors" do
+              expect(mail.body.encoded).to include(
+                "0 users have been successfully registered (1 detected, 1 errors)"
+              )
+            end
           end
         end
 
-        context "when the import had errors" do
-          let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 0, errors_count: 1) }
+        context "when the type is :revoked" do
+          let(:type) { :revoked }
 
-          it "sends the email to the passed user" do
-            expect(mail.to).to eq([user.email])
+          context "when the import had no errors" do
+            it "shows the number of errors" do
+              expect(mail.body.encoded).to include(
+                "Verification from 1 users have been revoked using [direct_verifications] (1 detected, 0 errors)"
+              )
+            end
           end
 
-          it "renders the subject" do
-            expect(mail.subject).to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.mailer.subject"))
-          end
+          context "when the import had errors" do
+            let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 0, errors_count: 1) }
 
-          it "localizes the subject" do
-            user.locale = "ca"
-            expect(I18n).to receive(:with_locale).with("ca")
-
-            mail.body
-          end
-
-          it "renders the body" do
-            expect(mail.body.encoded).to include(
-              "0 users have been successfully registered (1 detected, 1 errors)"
-            )
-          end
-
-          it "sets the organization" do
-            expect(mail.body.encoded).to include(user.organization.name)
+            it "shows the number of errors" do
+              expect(mail.body.encoded).to include(
+                "Verification from 0 users have been revoked using [direct_verifications] (1 detected, 1 errors)"
+              )
+            end
           end
         end
       end

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -30,11 +30,45 @@ describe "Admin imports users", type: :system do
 
         expect(page).to have_admin_callout("successfully")
         expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
+
         expect(Decidim::User.last.email).to eq("brandy@example.com")
 
-        expect(last_email_delivery.subject).to eq(I18n.t("#{i18n_scope}.imports.mailer.subject"))
         expect(last_email_delivery.body.encoded).to include(
-          I18n.t("#{i18n_scope}.direct_verifications.create.registered", count: 1, registered: 1, errors: 0)
+          I18n.t("#{i18n_scope}.imports.mailer.registered", count: 1, successful: 1, errors: 0)
+        )
+      end
+    end
+
+    context "when revoking users" do
+      let(:user_to_revoke) do
+        create(:user, name: "Brandy", email: "brandy@example.com", organization: organization)
+      end
+
+      before do
+        create(:authorization, :granted, user: user_to_revoke, name: :direct_verifications)
+      end
+
+      it "registers users through a CSV file" do
+        attach_file("CSV file with users data", filename)
+        choose(I18n.t("#{i18n_scope}.new.revoke"))
+
+        perform_enqueued_jobs do
+          click_button("Upload file")
+        end
+
+        expect(page).to have_admin_callout("successfully")
+        expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
+
+        expect(Decidim::Authorization.find_by(decidim_user_id: user_to_revoke.id)).to be_nil
+
+        expect(last_email_delivery.body.encoded).to include(
+          I18n.t(
+            "#{i18n_scope}.imports.mailer.revoked",
+            handler: :direct_verifications,
+            count: 1,
+            successful: 1,
+            errors: 0
+          )
         )
       end
     end


### PR DESCRIPTION
This abstracts things a bit so we need only a mailer method and its view. All the rest is handled passing the type of processing (register, revoke, etc.). Then, we add all the missing pieces for revocations to happened async: the Job class and the necessary branching in CreateImport depending on the action (or type). 