### PR TITLE
Implement registration mail

### DIFF
--- a/app/jobs/decidim/direct_verifications/register_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/register_users_job.rb
@@ -33,7 +33,7 @@ module Decidim
       end
 
       def send_email_notification
-        ImportMailer.successful_import(current_user).deliver_now
+        ImportMailer.finished_registration(current_user, instrumenter).deliver_now
       end
     end
   end

--- a/app/mailers/decidim/direct_verifications/import_mailer.rb
+++ b/app/mailers/decidim/direct_verifications/import_mailer.rb
@@ -3,17 +3,24 @@
 module Decidim
   module DirectVerifications
     class ImportMailer < Decidim::Admin::ApplicationMailer
+      Stats = Struct.new(:count, :registered, :errors, keyword_init: true)
+
       include LocalisedMailer
 
       layout "decidim/mailer"
 
-      def successful_import(user)
+      def finished_registration(user, instrumenter)
         @organization = user.organization
+        @stats = Stats.new(
+          count: instrumenter.emails_count(:registered),
+          registered: instrumenter.processed_count(:registered),
+          errors: instrumenter.errors_count(:registered)
+        )
 
         with_user(user) do
           mail(
             to: user.email,
-            subject: I18n.t("decidim.direct_verifications.verification.admin.imports.successful_import.subject")
+            subject: I18n.t("decidim.direct_verifications.verification.admin.imports.mailer.subject")
           )
         end
       end

--- a/app/mailers/decidim/direct_verifications/import_mailer.rb
+++ b/app/mailers/decidim/direct_verifications/import_mailer.rb
@@ -5,7 +5,11 @@ module Decidim
     class ImportMailer < Decidim::Admin::ApplicationMailer
       include LocalisedMailer
 
+      layout "decidim/mailer"
+
       def successful_import(user)
+        @organization = user.organization
+
         with_user(user) do
           mail(
             to: user.email,

--- a/app/views/decidim/direct_verifications/import_mailer/finished_registration.html.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_registration.html.erb
@@ -1,0 +1,1 @@
+<p><%= t("decidim.direct_verifications.verification.admin.direct_verifications.create.registered", count: @stats.count, registered: @stats.registered, errors: @stats.errors) %></p>

--- a/app/views/decidim/direct_verifications/import_mailer/finished_registration.text.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_registration.text.erb
@@ -1,0 +1,1 @@
+<%= t("decidim.direct_verifications.verification.admin.direct_verifications.create.registered", count: @stats.count, registered: @stats.registered, errors: @stats.errors) %>

--- a/app/views/decidim/direct_verifications/import_mailer/successful_import.html.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/successful_import.html.erb
@@ -1,1 +1,0 @@
-Register successful

--- a/config/initializers/mail_previews.rb
+++ b/config/initializers/mail_previews.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.action_mailer.preview_path = Decidim::DirectVerifications::Verification::Engine.root.join("spec/mailers")
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,8 +28,8 @@ en:
             create:
               success: successfully
               error: There was an error importing the file
-            successful_import:
-              subject: File imported successfully
+            mailer:
+              subject: Users processed
           authorizations:
             index:
               created_at: Created at

--- a/lib/decidim/direct_verifications/instrumenter.rb
+++ b/lib/decidim/direct_verifications/instrumenter.rb
@@ -25,6 +25,10 @@ module Decidim
         errors[key].size
       end
 
+      def emails_count(key)
+        @processed[key].size + @errors[key].size
+      end
+
       def track(event, email, user = nil)
         if user
           add_processed event, email

--- a/spec/jobs/decidim/direct_verifications/register_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/register_users_job_spec.rb
@@ -15,7 +15,10 @@ module Decidim
       end
 
       before do
-        allow(ImportMailer).to receive(:successful_import).with(current_user).and_return(mailer)
+        allow(ImportMailer)
+          .to receive(:finished_registration)
+          .with(current_user, kind_of(Instrumenter))
+          .and_return(mailer)
       end
 
       it "creates the user" do

--- a/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
+++ b/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
@@ -7,26 +7,65 @@ module Decidim
     describe ImportMailer, type: :mailer do
       let(:user) { build(:user) }
 
-      describe "#successful_import" do
-        subject(:mail) { described_class.successful_import(user) }
+      describe "#finished_registration" do
+        subject(:mail) { described_class.finished_registration(user, instrumenter) }
 
-        it "sends the email to the passed user" do
-          expect(mail.to).to eq([user.email])
+        context "when the import had no errors" do
+          let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 1, errors_count: 0) }
+
+          it "sends the email to the passed user" do
+            expect(mail.to).to eq([user.email])
+          end
+
+          it "renders the subject" do
+            expect(mail.subject).to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.mailer.subject"))
+          end
+
+          it "localizes the subject" do
+            user.locale = "ca"
+            expect(I18n).to receive(:with_locale).with("ca")
+
+            mail.body
+          end
+
+          it "renders the body" do
+            expect(mail.body.encoded).to include(
+              "1 users have been successfully registered (1 detected, 0 errors)"
+            )
+          end
+
+          it "sets the organization" do
+            expect(mail.body.encoded).to include(user.organization.name)
+          end
         end
 
-        it "localizes the subject" do
-          user.locale = "ca"
-          expect(I18n).to receive(:with_locale).with("ca")
+        context "when the import had errors" do
+          let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 0, errors_count: 1) }
 
-          mail.body
-        end
+          it "sends the email to the passed user" do
+            expect(mail.to).to eq([user.email])
+          end
 
-        it "renders the body" do
-          expect(mail.body.encoded).to include("Register successful")
-        end
+          it "renders the subject" do
+            expect(mail.subject).to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.mailer.subject"))
+          end
 
-        it "sets the organization" do
-          expect(mail.body.encoded).to include(user.organization.name)
+          it "localizes the subject" do
+            user.locale = "ca"
+            expect(I18n).to receive(:with_locale).with("ca")
+
+            mail.body
+          end
+
+          it "renders the body" do
+            expect(mail.body.encoded).to include(
+              "0 users have been successfully registered (1 detected, 1 errors)"
+            )
+          end
+
+          it "sets the organization" do
+            expect(mail.body.encoded).to include(user.organization.name)
+          end
         end
       end
     end

--- a/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
+++ b/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
@@ -5,10 +5,10 @@ require "spec_helper"
 module Decidim
   module DirectVerifications
     describe ImportMailer, type: :mailer do
+      let(:user) { build(:user) }
+
       describe "#successful_import" do
         subject(:mail) { described_class.successful_import(user) }
-
-        let(:user) { build(:user) }
 
         it "sends the email to the passed user" do
           expect(mail.to).to eq([user.email])
@@ -16,7 +16,6 @@ module Decidim
 
         it "localizes the subject" do
           user.locale = "ca"
-          user.save!
           expect(I18n).to receive(:with_locale).with("ca")
 
           mail.body

--- a/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
+++ b/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
@@ -24,6 +24,10 @@ module Decidim
         it "renders the body" do
           expect(mail.body.encoded).to include("Register successful")
         end
+
+        it "sets the organization" do
+          expect(mail.body.encoded).to include(user.organization.name)
+        end
       end
     end
   end

--- a/spec/mailers/previews/import_mailer_preview.rb
+++ b/spec/mailers/previews/import_mailer_preview.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Decidim
+  class ImportMailerPreview < ActionMailer::Preview
+    def successful_import
+      DirectVerifications::ImportMailer.successful_import(User.first)
+    end
+  end
+end

--- a/spec/mailers/previews/import_mailer_preview.rb
+++ b/spec/mailers/previews/import_mailer_preview.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 module Decidim
-  class ImportMailerPreview < ActionMailer::Preview
-    def successful_import
-      DirectVerifications::ImportMailer.successful_import(User.first)
+  module DirectVerifications
+    class ImportMailerPreview < ActionMailer::Preview
+      def finished_registration
+        user = User.first
+
+        instrumenter = Instrumenter.new(user)
+        instrumenter.add_processed(:registered, "email@example.com")
+
+        ImportMailer.finished_registration(user, instrumenter)
+      end
     end
   end
 end

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -6,6 +6,9 @@ describe "Admin imports users", type: :system do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :admin, :confirmed, organization: organization) }
 
+  let(:i18n_scope) { "decidim.direct_verifications.verification.admin" }
+  let(:last_email_delivery) { ActionMailer::Base.deliveries.last }
+
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
@@ -19,7 +22,7 @@ describe "Admin imports users", type: :system do
     context "when authorizing users" do
       it "registers users through a CSV file" do
         attach_file("CSV file with users data", filename)
-        choose(I18n.t("decidim.direct_verifications.verification.admin.new.authorize"))
+        choose(I18n.t("#{i18n_scope}.new.authorize"))
 
         perform_enqueued_jobs do
           click_button("Upload file")
@@ -28,8 +31,11 @@ describe "Admin imports users", type: :system do
         expect(page).to have_admin_callout("successfully")
         expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
         expect(Decidim::User.last.email).to eq("brandy@example.com")
-        expect(ActionMailer::Base.deliveries.last.subject)
-          .to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.successful_import.subject"))
+
+        expect(last_email_delivery.subject).to eq(I18n.t("#{i18n_scope}.imports.mailer.subject"))
+        expect(last_email_delivery.body.encoded).to include(
+          I18n.t("#{i18n_scope}.direct_verifications.create.registered", count: 1, registered: 1, errors: 0)
+        )
       end
     end
   end

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -16,18 +16,21 @@ describe "Admin imports users", type: :system do
   context "when visiting the imports page" do
     let(:filename) { file_fixture("users.csv") }
 
-    it "enables uploading a CSV file" do
-      attach_file("CSV file with users data", filename)
+    context "when authorizing users" do
+      it "registers users through a CSV file" do
+        attach_file("CSV file with users data", filename)
+        choose(I18n.t("decidim.direct_verifications.verification.admin.new.authorize"))
 
-      perform_enqueued_jobs do
-        click_button("Upload file")
+        perform_enqueued_jobs do
+          click_button("Upload file")
+        end
+
+        expect(page).to have_admin_callout("successfully")
+        expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
+        expect(Decidim::User.last.email).to eq("brandy@example.com")
+        expect(ActionMailer::Base.deliveries.last.subject)
+          .to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.successful_import.subject"))
       end
-
-      expect(page).to have_admin_callout("successfully")
-      expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
-      expect(Decidim::User.last.email).to eq("brandy@example.com")
-      expect(ActionMailer::Base.deliveries.last.subject)
-        .to eq(I18n.t("decidim.direct_verifications.verification.admin.imports.successful_import.subject"))
     end
   end
 end


### PR DESCRIPTION
Extends the dummy mail view for successful user registrations, which looks like

![Screenshot from 2021-04-13 15-36-31](https://user-images.githubusercontent.com/762088/114561787-2bcb2000-9c6e-11eb-95fd-0ddf1af97e4e.png)

A single email notification serves both the success and failure scenarios. We just the counts of successfully and unsuccessfully processed user entries.

Further enhancements can be done in the future if needed, such as having a different subject depending on errors. For now, I think this just adds complexity and makes development tedious.