### PR TITLE
Extract base job class and use template methods

### DIFF
--- a/app/jobs/decidim/direct_verifications/base_import_job.rb
+++ b/app/jobs/decidim/direct_verifications/base_import_job.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "decidim/direct_verifications/instrumenter"
+
+module Decidim
+  module DirectVerifications
+    class BaseImportJob < ApplicationJob
+      queue_as :default
+
+      def perform(userslist, organization, current_user)
+        @emails = Verification::MetadataParser.new(userslist).to_h
+        @organization = organization
+        @current_user = current_user
+        @instrumenter = Instrumenter.new(current_user)
+
+        process_users
+        send_email_notification
+      end
+
+      private
+
+      attr_reader :emails, :organization, :current_user, :instrumenter
+    end
+  end
+end

--- a/app/jobs/decidim/direct_verifications/register_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/register_users_job.rb
@@ -4,24 +4,8 @@ require "decidim/direct_verifications/instrumenter"
 
 module Decidim
   module DirectVerifications
-    class RegisterUsersJob < ApplicationJob
-      queue_as :default
-
-      def perform(userslist, organization, user)
-        @emails = Verification::MetadataParser.new(userslist).to_h
-        @organization = organization
-        @current_user = user
-        @instrumenter = Instrumenter.new(current_user)
-
-        register_users
-        send_email_notification
-      end
-
-      private
-
-      attr_reader :organization, :current_user, :instrumenter, :emails
-
-      def register_users
+    class RegisterUsersJob < BaseImportJob
+      def process_users
         emails.each do |email, data|
           name = if data.is_a?(Hash)
                    data[:name]

--- a/app/jobs/decidim/direct_verifications/revoke_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/revoke_users_job.rb
@@ -2,24 +2,8 @@
 
 module Decidim
   module DirectVerifications
-    class RevokeUsersJob < ApplicationJob
-      queue_as :default
-
-      def perform(userslist, organization, current_user)
-        @emails = Verification::MetadataParser.new(userslist).to_h
-        @organization = organization
-        @current_user = current_user
-        @instrumenter = Instrumenter.new(current_user)
-
-        revoke_users
-        send_email_notification
-      end
-
-      private
-
-      attr_reader :emails, :organization, :current_user, :instrumenter
-
-      def revoke_users
+    class RevokeUsersJob < BaseImportJob
+      def process_users
         emails.each do |email, _name|
           RevokeUser.new(email, organization, instrumenter).call
         end


### PR DESCRIPTION
This makes the algorithm more obvious and job classes less boilerplate-ish.