### PR TITLE
Improve import form

### DIFF
--- a/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
@@ -7,6 +7,7 @@ module Decidim
         class ImportsController < Decidim::Admin::ApplicationController
           def new
             enforce_permission_to :create, :authorization
+            @form = form(CreateImportForm).instance
           end
 
           def create

--- a/app/forms/decidim/direct_verifications/verification/create_import_form.rb
+++ b/app/forms/decidim/direct_verifications/verification/create_import_form.rb
@@ -13,9 +13,9 @@ module Decidim
         attribute :file
         attribute :organization, Decidim::Organization
         attribute :user, Decidim::User
-        attribute :authorize
+        attribute :authorize, String
 
-        validates :file, :organization, :user, presence: true
+        validates :file, :organization, :user, :authorize, presence: true
         validates :authorize, inclusion: { in: ACTIONS.keys }
 
         def action

--- a/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
@@ -7,9 +7,10 @@
     </h2>
   </div>
   <div class="card-section">
-    <p><%= t("decidim.direct_verifications.verification.admin.new.info") %></p>
+    <p><%= t("decidim.direct_verifications.verification.admin.imports.new.info") %></p>
     <pre class="code-block">
-    foo
+      <strong><%= t("decidim.direct_verifications.verification.admin.imports.new.template.header") %></strong>
+      <%= t("decidim.direct_verifications.verification.admin.imports.new.template.body") %>
     </pre>
 
     <%= decidim_form_for(@form, url: imports_path, html: { class: "form" }) do |form| %>

--- a/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
@@ -13,7 +13,6 @@
     </pre>
 
     <%= decidim_form_for(@form, url: imports_path, html: { class: "form" }) do |form| %>
-      <%= label_tag :userslist, t("admin.new.textarea", scope: "decidim.direct_verifications.verification") %>
       <label>
         <%= check_box_tag :register %>
         <%= t("admin.new.register", scope: "decidim.direct_verifications.verification") %>

--- a/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
@@ -11,7 +11,8 @@
     <pre class="code-block">
     foo
     </pre>
-    <%= form_tag imports_path, multipart: true, class: "form" do %>
+
+    <%= decidim_form_for(@form, url: imports_path, html: { class: "form" }) do |form| %>
       <%= label_tag :userslist, t("admin.new.textarea", scope: "decidim.direct_verifications.verification") %>
       <label>
         <%= check_box_tag :register %>
@@ -35,9 +36,8 @@
 
       <%# TODO: add authorization_handler field %>
 
-      <%= label_tag :file, t(".file") %>
-      <%= file_field_tag :file %>
-      <%= submit_tag t(".submit"), class: "button" %>
+      <%= form.file_field :file, label: t(".file") %>
+      <%= form.submit t(".submit"), class: "button" %>
     <% end %>
 
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,14 @@ en:
         admin:
           imports:
             new:
+              info: Import a CSV file with a user entry per line copying the format from the example below
+              template:
+                header: email, name, membership_phone, membership_type, membership_weight
+                body: |
+                  ava@example.com, Ava Hawkins, +3476318371, consumer, 1
+                  ewan@example.com, Ewan Cooper, +34653565765, worker, 1
+                  tilly@example.com, Tilly Jones, +34653565761, collaborator, 0.67
+                  ...
               submit: Upload file
               file: CSV file with users data
             create:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,7 +26,7 @@ en:
               submit: Upload file
               file: CSV file with users data
             create:
-              success: successfully
+              success: File successfully uploaded. We'll email you when all users are imported.
               error: There was an error importing the file
             mailer:
               subject: Users processed

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -28,7 +28,7 @@ describe "Admin imports users", type: :system do
           click_button("Upload file")
         end
 
-        expect(page).to have_admin_callout("successfully")
+        expect(page).to have_admin_callout(I18n.t("#{i18n_scope}.imports.create.success"))
         expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
 
         expect(Decidim::User.last.email).to eq("brandy@example.com")


### PR DESCRIPTION
Enhances the import form with client-side validation and proper copies.

![Screenshot from 2021-04-14 17-44-41](https://user-images.githubusercontent.com/762088/114739390-1c6cd500-9d49-11eb-9216-b24b42c23f64.png)


I couldn't manage to remove that leading whitespace. It's ugly but it's not a big deal. We'll solve it later on.

Note that, in terms of UX, the solution we're aiming for is to give users a CSV file template they can download
and modify but in the meantime, this is more straightforward to implement and lets us demo it already.