### PR TITLE
Enable registering and authorizing users async

### DIFF
--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -18,6 +18,10 @@ module Decidim
           case action
           when :register
             register_users_async
+          when :register_and_authorize
+            register_users_async
+            file.rewind
+            authorize_users_async
           when :revoke
             revoke_users_async
           end
@@ -35,6 +39,10 @@ module Decidim
 
         def revoke_users_async
           RevokeUsersJob.perform_later(file.read, organization, user)
+        end
+
+        def authorize_users_async
+          AuthorizeUsersJob.perform_later(file.read, organization, user)
         end
       end
     end

--- a/app/forms/decidim/direct_verifications/verification/create_import_form.rb
+++ b/app/forms/decidim/direct_verifications/verification/create_import_form.rb
@@ -5,7 +5,7 @@ module Decidim
     module Verification
       class CreateImportForm < Form
         ACTIONS = {
-          "in" => :register,
+          "in" => :authorize,
           "out" => :revoke,
           "check" => :check
         }.freeze
@@ -14,12 +14,19 @@ module Decidim
         attribute :organization, Decidim::Organization
         attribute :user, Decidim::User
         attribute :authorize, String
+        attribute :register, Boolean
 
         validates :file, :organization, :user, :authorize, presence: true
         validates :authorize, inclusion: { in: ACTIONS.keys }
 
         def action
-          ACTIONS[authorize]
+          if register && authorize == "in"
+            :register_and_authorize
+          elsif register
+            :register
+          else
+            ACTIONS[authorize]
+          end
         end
       end
     end

--- a/app/jobs/decidim/direct_verifications/authorize_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/authorize_users_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "decidim/direct_verifications/instrumenter"
+
+module Decidim
+  module DirectVerifications
+    class AuthorizeUsersJob < BaseImportJob
+      class NullSession; end
+
+      def process_users
+        emails.each do |email, data|
+          AuthorizeUser.new(email, data, session, organization, instrumenter).call
+        end
+      end
+
+      def type
+        :authorized
+      end
+
+      private
+
+      def session
+        NullSession.new
+      end
+    end
+  end
+end

--- a/spec/forms/decidim/direct_verifications/verification/create_import_form_spec.rb
+++ b/spec/forms/decidim/direct_verifications/verification/create_import_form_spec.rb
@@ -22,34 +22,87 @@ module Decidim
           it { is_expected.to be_valid }
         end
 
-        context "when action is in" do
-          let(:action) { "in" }
+        context "when :register is provided" do
+          let(:attributes) do
+            {
+              user: build(:user),
+              organization: build(:organization),
+              file: double(File),
+              authorize: action,
+              register: "1"
+            }
+          end
 
-          it "returns it as :register" do
-            expect(form.action).to eq(:register)
+          context "when action is in" do
+            let(:action) { "in" }
+
+            it "returns it as :register_and_authorize" do
+              expect(form.action).to eq(:register_and_authorize)
+            end
+          end
+
+          context "when action is out" do
+            let(:action) { "out" }
+
+            it "returns it as :register" do
+              expect(form.action).to eq(:register)
+            end
+          end
+
+          context "when action is check" do
+            let(:action) { "check" }
+
+            it "returns it as :register" do
+              expect(form.action).to eq(:register)
+            end
+          end
+
+          context "when action is unknown" do
+            let(:action) { "dummy" }
+
+            it { is_expected.not_to be_valid }
           end
         end
 
-        context "when action is out" do
-          let(:action) { "out" }
-
-          it "returns it as :revoke" do
-            expect(form.action).to eq(:revoke)
+        context "when :register is not provided" do
+          let(:attributes) do
+            {
+              user: build(:user),
+              organization: build(:organization),
+              file: double(File),
+              authorize: action
+            }
           end
-        end
 
-        context "when action is check" do
-          let(:action) { "check" }
+          context "when action is in" do
+            let(:action) { "in" }
 
-          it "returns it as :check" do
-            expect(form.action).to eq(:check)
+            it "returns it as :authorize" do
+              expect(form.action).to eq(:authorize)
+            end
           end
-        end
 
-        context "when action is unknown" do
-          let(:action) { "dummy" }
+          context "when action is out" do
+            let(:action) { "out" }
 
-          it { is_expected.not_to be_valid }
+            it "returns it as :revoke" do
+              expect(form.action).to eq(:revoke)
+            end
+          end
+
+          context "when action is check" do
+            let(:action) { "check" }
+
+            it "returns it as :check" do
+              expect(form.action).to eq(:check)
+            end
+          end
+
+          context "when action is unknown" do
+            let(:action) { "dummy" }
+
+            it { is_expected.not_to be_valid }
+          end
         end
       end
     end

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -9,6 +9,8 @@ describe "Admin imports users", type: :system do
   let(:i18n_scope) { "decidim.direct_verifications.verification.admin" }
   let(:last_email_delivery) { ActionMailer::Base.deliveries.last }
 
+  let(:filename) { file_fixture("users.csv") }
+
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
@@ -16,61 +18,89 @@ describe "Admin imports users", type: :system do
     visit decidim_admin_direct_verifications.new_import_path
   end
 
-  context "when visiting the imports page" do
-    let(:filename) { file_fixture("users.csv") }
+  context "when registering users" do
+    it "registers users through a CSV file" do
+      attach_file("CSV file with users data", filename)
 
-    context "when authorizing users" do
-      it "registers users through a CSV file" do
-        attach_file("CSV file with users data", filename)
-        choose(I18n.t("#{i18n_scope}.new.authorize"))
+      check(I18n.t("#{i18n_scope}.new.register"))
 
-        perform_enqueued_jobs do
-          click_button("Upload file")
-        end
-
-        expect(page).to have_admin_callout(I18n.t("#{i18n_scope}.imports.create.success"))
-        expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
-
-        expect(Decidim::User.last.email).to eq("brandy@example.com")
-
-        expect(last_email_delivery.body.encoded).to include(
-          I18n.t("#{i18n_scope}.imports.mailer.registered", count: 1, successful: 1, errors: 0)
-        )
+      perform_enqueued_jobs do
+        click_button("Upload file")
       end
+
+      expect(page).to have_admin_callout(I18n.t("#{i18n_scope}.imports.create.success"))
+      expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
+
+      expect(Decidim::User.last.email).to eq("brandy@example.com")
+
+      expect(last_email_delivery.body.encoded).to include(
+        I18n.t("#{i18n_scope}.imports.mailer.registered", count: 1, successful: 1, errors: 0)
+      )
+    end
+  end
+
+  context "when registering and authorizing users" do
+    it "registers and authorizes users through a CSV file" do
+      attach_file("CSV file with users data", filename)
+
+      check(I18n.t("#{i18n_scope}.new.register"))
+      choose(I18n.t("#{i18n_scope}.new.authorize"))
+
+      perform_enqueued_jobs do
+        click_button("Upload file")
+      end
+
+      expect(page).to have_admin_callout(I18n.t("#{i18n_scope}.imports.create.success"))
+      expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
+
+      user = Decidim::User.last
+      expect(user.email).to eq("brandy@example.com")
+      expect(Decidim::Authorization.find_by(decidim_user_id: user.id)).not_to be_nil
+
+      expect(last_email_delivery.body.encoded).to include(
+        I18n.t(
+          "#{i18n_scope}.imports.mailer.authorized",
+          handler: :direct_verifications,
+          count: 1,
+          successful: 1,
+          errors: 0
+        )
+      )
+    end
+  end
+
+  context "when revoking users" do
+    let(:user_to_revoke) do
+      create(:user, name: "Brandy", email: "brandy@example.com", organization: organization)
     end
 
-    context "when revoking users" do
-      let(:user_to_revoke) do
-        create(:user, name: "Brandy", email: "brandy@example.com", organization: organization)
+    before do
+      create(:authorization, :granted, user: user_to_revoke, name: :direct_verifications)
+    end
+
+    it "registers users through a CSV file" do
+      attach_file("CSV file with users data", filename)
+
+      choose(I18n.t("#{i18n_scope}.new.revoke"))
+
+      perform_enqueued_jobs do
+        click_button("Upload file")
       end
 
-      before do
-        create(:authorization, :granted, user: user_to_revoke, name: :direct_verifications)
-      end
+      expect(page).to have_admin_callout("successfully")
+      expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
 
-      it "registers users through a CSV file" do
-        attach_file("CSV file with users data", filename)
-        choose(I18n.t("#{i18n_scope}.new.revoke"))
+      expect(Decidim::Authorization.find_by(decidim_user_id: user_to_revoke.id)).to be_nil
 
-        perform_enqueued_jobs do
-          click_button("Upload file")
-        end
-
-        expect(page).to have_admin_callout("successfully")
-        expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
-
-        expect(Decidim::Authorization.find_by(decidim_user_id: user_to_revoke.id)).to be_nil
-
-        expect(last_email_delivery.body.encoded).to include(
-          I18n.t(
-            "#{i18n_scope}.imports.mailer.revoked",
-            handler: :direct_verifications,
-            count: 1,
-            successful: 1,
-            errors: 0
-          )
+      expect(last_email_delivery.body.encoded).to include(
+        I18n.t(
+          "#{i18n_scope}.imports.mailer.revoked",
+          handler: :direct_verifications,
+          count: 1,
+          successful: 1,
+          errors: 0
         )
-      end
+      )
     end
   end
 end


### PR DESCRIPTION
This fixes the confusion we had with how the registering and authorizing actions are sent from the form. The former is optional but authorizing, revoking and checking come from radio buttons so there'll always come one in the request. Because the radio button enabled by default is "check", if only registering is select we'll only register users. See `create_import_form_spec.rb` for all the permutations.

Note we don't do any processing when "check" is provided yet.