### PR TITLE
Fix leading whitespace by removing I18n-ability

### DIFF
--- a/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
@@ -9,8 +9,11 @@
   <div class="card-section">
     <p><%= t("decidim.direct_verifications.verification.admin.imports.new.info") %></p>
     <pre class="code-block">
-      <strong><%= t("decidim.direct_verifications.verification.admin.imports.new.template.header") %></strong>
-      <%= t("decidim.direct_verifications.verification.admin.imports.new.template.body") %>
+      <strong>email, name, membership_phone, membership_type, membership_weight</strong>
+      ava@example.com, Ava Hawkins, +3476318371, consumer, 1
+      ewan@example.com, Ewan Cooper, +34653565765, worker, 1
+      tilly@example.com, Tilly Jones, +34653565761, collaborator, 0.67
+      ...
     </pre>
 
     <%= decidim_form_for(@form, url: imports_path, html: { class: "form" }) do |form| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,13 +24,6 @@ en:
           imports:
             new:
               info: Import a CSV file with a user entry per line copying the format from the example below
-              template:
-                header: email, name, membership_phone, membership_type, membership_weight
-                body: |
-                  ava@example.com, Ava Hawkins, +3476318371, consumer, 1
-                  ewan@example.com, Ewan Cooper, +34653565765, worker, 1
-                  tilly@example.com, Tilly Jones, +34653565761, collaborator, 0.67
-                  ...
               submit: Upload file
               file: CSV file with users data
             create:


### PR DESCRIPTION
I changed my mind. It's not worth making this translatable at this early stage and I find this leading whitespace worse than having only an English version of the template.