### PR TITLE
Allow trailing and leading whitespaces in CSVs

### DIFF
--- a/app/commands/decidim/direct_verifications/verification/metadata_parser.rb
+++ b/app/commands/decidim/direct_verifications/verification/metadata_parser.rb
@@ -9,8 +9,8 @@ module Decidim
         def header
           @header ||= begin
                         header_row = lines[0].chomp
-                        column_names = tokenize(header_row)
-                        column_names.map(&:to_sym).map(&:downcase)
+                        header_row = tokenize(header_row)
+                        normalize_header(header_row)
                       end
         end
 
@@ -23,7 +23,7 @@ module Decidim
 
           hash = {}
           header.each_with_index do |column, index|
-            value = tokens[index].strip
+            value = tokens[index]
             next if value.include?(email)
 
             hash[column] = value
@@ -34,7 +34,13 @@ module Decidim
         private
 
         def tokenize(line)
-          CSV.parse(line)[0]
+          CSV.parse(line)[0].map(&:strip)
+        end
+
+        def normalize_header(line)
+          line.map do |text|
+            text.to_sym.downcase
+          end
         end
       end
     end

--- a/spec/commands/decidim/direct_verifications/verification/metadata_parser_spec.rb
+++ b/spec/commands/decidim/direct_verifications/verification/metadata_parser_spec.rb
@@ -68,6 +68,21 @@ module Decidim::DirectVerifications::Verification
           end
         end
 
+        context "and the CSV includes trailing or leading whitespaces" do
+          let(:txt) do
+            <<-CSV.strip_heredoc
+            Name, Email, Type
+            Ava Hawkins, ava@example.com, collaborator
+            CSV
+          end
+
+          it "returns the data in a hash with the email as key" do
+            expect(subject.to_h).to eq(
+              "ava@example.com" => { name: "Ava Hawkins", type: "collaborator" }
+            )
+          end
+        end
+
         context "when the name is not specified" do
           let(:txt) do
             <<-EMAILS.strip_heredoc

--- a/spec/fixtures/files/users.csv
+++ b/spec/fixtures/files/users.csv
@@ -1,2 +1,2 @@
-Name,Email,Type
-Brandy,brandy@example.com,consumer
+Name, Email, Type
+Brandy, brandy@example.com, consumer


### PR DESCRIPTION
The extra whitespace caused `RegisterUser`'s form to return a nil `#name` and thus, the fallback name was used although the CSV contained a name column.

While at it, I also tried to make the system tests more closely mimic the manual acceptance test I'm doing when checking the email in my inbox. That's how I noticed the `Hola saulopefa+ava_test,` wasn't what I expected.