### PR TITLE
Fix parsing empty columns

### DIFF
--- a/app/commands/decidim/direct_verifications/verification/metadata_parser.rb
+++ b/app/commands/decidim/direct_verifications/verification/metadata_parser.rb
@@ -24,8 +24,7 @@ module Decidim
           hash = {}
           header.each_with_index do |column, index|
             value = tokens[index]
-            next if value.nil?
-            next if value.include?(email)
+            next if value&.include?(email)
 
             hash[column] = value
           end
@@ -36,11 +35,7 @@ module Decidim
 
         def tokenize(line)
           CSV.parse_line(line).map do |token|
-            if token.nil?
-              nil
-            else
-              token.strip
-            end
+            token&.strip
           end
         end
 

--- a/spec/commands/decidim/direct_verifications/verification/metadata_parser_spec.rb
+++ b/spec/commands/decidim/direct_verifications/verification/metadata_parser_spec.rb
@@ -39,7 +39,7 @@ module Decidim::DirectVerifications::Verification
 
         it "skips those columns" do
           expect(subject.to_h).to eq(
-            "bob@example.com" => { name: "Bob", salary: "1000" }
+            "bob@example.com" => { department: nil, name: "Bob", salary: "1000" }
           )
         end
       end

--- a/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
+++ b/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
@@ -113,6 +113,20 @@ module Decidim::DirectVerifications::Verification::Admin
             expect(authorization.metadata).to eq("name" => "Brandy", "type" => "consumer")
           end
 
+          context "when a column is empty" do
+            it "sets it nil" do
+              post :create, params: {
+                userslist: "Name,Email,Type,City\r\nBrandy,brandy@example.com,,Barcelona",
+                register: true,
+                authorize: "in"
+              }
+
+              user = Decidim::User.find_by(email: "brandy@example.com")
+              authorization = Decidim::Authorization.find_by(decidim_user_id: user.id)
+              expect(authorization.metadata).to eq("name" => "Brandy", "type" => nil, "city" => "Barcelona")
+            end
+          end
+
           context "when the name is not specified" do
             it "infers the name from the email" do
               post :create, params: {

--- a/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
+++ b/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
@@ -32,10 +32,13 @@ module Decidim::DirectVerifications::Verification::Admin
     describe "POST create" do
       context "when parameters are defaults" do
         params = { userslist: "" }
+
         it_behaves_like "checking users", params
+
         it "have no registered or authorized users" do
           perform_enqueued_jobs do
             post :create, params: params
+
             expect(flash[:info]).to include("0 are registered")
             expect(flash[:info]).to include("0 authorized")
             expect(flash[:info]).to include("unconfirmed")
@@ -62,7 +65,9 @@ module Decidim::DirectVerifications::Verification::Admin
         it "renders the index with warning message" do
           perform_enqueued_jobs do
             post :create, params: params
-            expect(subject).to render_template("decidim/direct_verifications/verification/admin/direct_verifications/index")
+            expect(subject).to render_template(
+              "decidim/direct_verifications/verification/admin/direct_verifications/index"
+            )
           end
         end
       end
@@ -81,12 +86,10 @@ module Decidim::DirectVerifications::Verification::Admin
         end
 
         context "when the name is not specified" do
+          let(:data) { "Name,Email,Type\r\n\"\",brandy@example.com,consumer" }
+
           it "infers the name from the email" do
-            post :create, params: {
-              userslist: "Name,Email,Type\r\n\"\",brandy@example.com,consumer",
-              register: true,
-              authorize: "in"
-            }
+            post :create, params: { userslist: data, register: true, authorize: "in" }
 
             user = Decidim::User.find_by(email: "brandy@example.com")
             expect(user.name).to eq("brandy")
@@ -94,6 +97,10 @@ module Decidim::DirectVerifications::Verification::Admin
         end
 
         context "when in metadata mode" do
+          let(:data) do
+            "Name,Email,Type\r\nBrandy,brandy@example.com,consumer,2\r\nWhisky,whisky@example.com,producer,3"
+          end
+
           around do |example|
             original_processor = Rails.configuration.direct_verifications_parser
             Rails.configuration.direct_verifications_parser = :metadata
@@ -102,11 +109,7 @@ module Decidim::DirectVerifications::Verification::Admin
           end
 
           it "stores any extra columns as authorization metadata" do
-            post :create, params: {
-              userslist: "Name,Email,Type\r\nBrandy,brandy@example.com,consumer,2\r\nWhisky,whisky@example.com,producer,3",
-              register: true,
-              authorize: "in"
-            }
+            post :create, params: { userslist: data, register: true, authorize: "in" }
 
             user = Decidim::User.find_by(email: "brandy@example.com")
             authorization = Decidim::Authorization.find_by(decidim_user_id: user.id)
@@ -114,26 +117,24 @@ module Decidim::DirectVerifications::Verification::Admin
           end
 
           context "when a column is empty" do
+            let(:data) { "Name,Email,Type,City\r\nBrandy,brandy@example.com,,Barcelona" }
+
             it "sets it nil" do
-              post :create, params: {
-                userslist: "Name,Email,Type,City\r\nBrandy,brandy@example.com,,Barcelona",
-                register: true,
-                authorize: "in"
-              }
+              post :create, params: { userslist: data, register: true, authorize: "in" }
 
               user = Decidim::User.find_by(email: "brandy@example.com")
               authorization = Decidim::Authorization.find_by(decidim_user_id: user.id)
-              expect(authorization.metadata).to eq("name" => "Brandy", "type" => nil, "city" => "Barcelona")
+
+              expect(authorization.metadata)
+                .to eq("name" => "Brandy", "type" => nil, "city" => "Barcelona")
             end
           end
 
           context "when the name is not specified" do
+            let(:data) { "Name,Email,Type\r\n\"\",brandy@example.com,consumer" }
+
             it "infers the name from the email" do
-              post :create, params: {
-                userslist: "Name,Email,Type\r\n\"\",brandy@example.com,consumer",
-                register: true,
-                authorize: "in"
-              }
+              post :create, params: { userslist: data, register: true, authorize: "in" }
 
               user = Decidim::User.find_by(email: "brandy@example.com")
               expect(user.name).to eq("brandy")


### PR DESCRIPTION
Closes https://github.com/coopdevs/decidim-coopcat/issues/132. I messed it up and pushed cea1f53cdfcf45e16e2ace8ec04b52b5e4cbec39 to `async-csv-import` without creating a branch first #classic. This finishes that up. Any missing CSV columns which have their CSV header will be saved as `nil` in the authorization's metadata column. This will allow us to know whether the input was broken in the first place.