### PR TITLE
Navigate to CSV import from /direct_verifications

### DIFF
--- a/app/views/decidim/direct_verifications/verification/admin/direct_verifications/index.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/direct_verifications/index.html.erb
@@ -7,7 +7,7 @@
     </h2>
   </div>
   <div class="card-section">
-    <p><%= t("decidim.direct_verifications.verification.admin.new.info") %></p>
+    <p><%= t("decidim.direct_verifications.verification.admin.new.info_html", link: new_import_path) %></p>
     <%= form_tag direct_verifications_path, multipart: true, class: "form" do %>
       <%= label_tag :userslist, t("admin.new.textarea", scope: "decidim.direct_verifications.verification") %>
       <%= text_area_tag :userslist, @userslist, rows: 10 %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,8 +68,7 @@ en:
             authorization_handler: Verification method
             authorize: Authorize users
             check: Check users status
-            info: Enter the emails here, one per line. If the emails are preceded
-              by a text, it will be interpreted as the user's name
+            info_html: You can <a href=%{link}>import a CSV</a> or enter the emails here, one per line. If the emails are preceded by a text, it will be interpreted as the user's name.
             register: Register users in the platform (if they exist they will be ignored)
             revoke: Revoke authorization from users
             submit: Send and process the list

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -16,6 +16,12 @@ describe "Admin imports users", type: :system do
     visit decidim_admin_direct_verifications.new_import_path
   end
 
+  it "can be accessed from direct_verifications_path" do
+    visit decidim_admin_direct_verifications.direct_verifications_path
+    click_link "import a CSV"
+    expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
+  end
+
   context "when registering users" do
     it "registers users through a CSV file" do
       attach_file("CSV file with users data", filename)


### PR DESCRIPTION
Closes https://github.com/coopdevs/decidim-coopcat/issues/134.

This simply makes it possible to reach the /direct_verifications/imports/new page previously introduced and demoed to ICA; the customer that requested this feature.

