### PR TITLE
Serialize file path instead of its contents

### DIFF
--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -34,15 +34,15 @@ module Decidim
         attr_reader :form, :file, :organization, :user, :action
 
         def register_users_async
-          RegisterUsersJob.perform_later(file.read, organization, user)
+          RegisterUsersJob.perform_later(file.path, organization, user)
         end
 
         def revoke_users_async
-          RevokeUsersJob.perform_later(file.read, organization, user)
+          RevokeUsersJob.perform_later(file.path, organization, user)
         end
 
         def authorize_users_async
-          AuthorizeUsersJob.perform_later(file.read, organization, user)
+          AuthorizeUsersJob.perform_later(file.path, organization, user)
         end
       end
     end

--- a/app/jobs/decidim/direct_verifications/base_import_job.rb
+++ b/app/jobs/decidim/direct_verifications/base_import_job.rb
@@ -10,7 +10,8 @@ module Decidim
     class BaseImportJob < ApplicationJob
       queue_as :default
 
-      def perform(userslist, organization, current_user)
+      def perform(path, organization, current_user)
+        userslist = File.read(path)
         @emails = Verification::MetadataParser.new(userslist).to_h
         @organization = organization
         @current_user = current_user

--- a/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
@@ -25,13 +25,23 @@ module Decidim
       end
 
       it "deletes the user authorization" do
-        described_class.perform_later(userslist, organization, current_user)
-        expect(Decidim::Authorization.find_by(id: authorization.id)).to be_nil
+        Tempfile.create("import.csv") do |file|
+          file.write(userslist)
+          file.rewind
+
+          described_class.perform_later(file.path, organization, current_user)
+          expect(Decidim::Authorization.find_by(id: authorization.id)).to be_nil
+        end
       end
 
       it "notifies the result by email" do
-        described_class.perform_later(userslist, organization, current_user)
-        expect(mailer).to have_received(:deliver_now)
+        Tempfile.create("import.csv") do |file|
+          file.write(userslist)
+          file.rewind
+
+          described_class.perform_later(file.path, organization, current_user)
+          expect(mailer).to have_received(:deliver_now)
+        end
       end
     end
   end


### PR DESCRIPTION
There's no way passing the file contents as a serialized argument could end well.