### PR TITLE
Revert "Merge pull request #23 from coopdevs/dont-serialize-file-contents"

### DIFF
--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -34,15 +34,15 @@ module Decidim
         attr_reader :form, :file, :organization, :user, :action
 
         def register_users_async
-          RegisterUsersJob.perform_later(file.path, organization, user)
+          RegisterUsersJob.perform_later(file.read, organization, user)
         end
 
         def revoke_users_async
-          RevokeUsersJob.perform_later(file.path, organization, user)
+          RevokeUsersJob.perform_later(file.read, organization, user)
         end
 
         def authorize_users_async
-          AuthorizeUsersJob.perform_later(file.path, organization, user)
+          AuthorizeUsersJob.perform_later(file.read, organization, user)
         end
       end
     end

--- a/app/jobs/decidim/direct_verifications/base_import_job.rb
+++ b/app/jobs/decidim/direct_verifications/base_import_job.rb
@@ -10,8 +10,7 @@ module Decidim
     class BaseImportJob < ApplicationJob
       queue_as :default
 
-      def perform(path, organization, current_user)
-        userslist = File.read(path)
+      def perform(userslist, organization, current_user)
         @emails = Verification::MetadataParser.new(userslist).to_h
         @organization = organization
         @current_user = current_user

--- a/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
@@ -25,23 +25,13 @@ module Decidim
       end
 
       it "deletes the user authorization" do
-        Tempfile.create("import.csv") do |file|
-          file.write(userslist)
-          file.rewind
-
-          described_class.perform_later(file.path, organization, current_user)
-          expect(Decidim::Authorization.find_by(id: authorization.id)).to be_nil
-        end
+        described_class.perform_later(userslist, organization, current_user)
+        expect(Decidim::Authorization.find_by(id: authorization.id)).to be_nil
       end
 
       it "notifies the result by email" do
-        Tempfile.create("import.csv") do |file|
-          file.write(userslist)
-          file.rewind
-
-          described_class.perform_later(file.path, organization, current_user)
-          expect(mailer).to have_received(:deliver_now)
-        end
+        described_class.perform_later(userslist, organization, current_user)
+        expect(mailer).to have_received(:deliver_now)
       end
     end
   end


### PR DESCRIPTION
This reverts commit 9e30bad3d239ebda576c1b8106875581ef8ed81e, reversing changes made to a6f4dcbf10ab703d6ca69912589b91cde6ad31e4.

What a fiasco. I knew implementing fixes on a Friday afternoon is not a good idea :see_no_evil: . I later realized I was fooled by the dev setup where both app server and background worker runs on the same file system and thus, the latter has access to the tmp path created by the former. The way to overcome this would be to upload the file straight to the object storage where the worker can pick it up from.

It's much quicker to revert this and keep serializing the file contents as a job argument. I checked with a 100 users CSV file and indeed, while the POST HTTP request only includes the file object instance as an argument, a job with a very large argument list gets enqueued but things keep working. We haven't hit any length limit. 
