### PR TITLE
Show error when no CSV header is provided

### DIFF
--- a/app/commands/decidim/direct_verifications/verification/metadata_parser.rb
+++ b/app/commands/decidim/direct_verifications/verification/metadata_parser.rb
@@ -40,8 +40,10 @@ module Decidim
         end
 
         def normalize_header(line)
-          line.map do |text|
-            text.to_sym.downcase
+          line.map do |field|
+            raise MissingHeaderError if field.nil?
+
+            field.to_sym.downcase
           end
         end
       end

--- a/app/commands/decidim/direct_verifications/verification/missing_header_error.rb
+++ b/app/commands/decidim/direct_verifications/verification/missing_header_error.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DirectVerifications
+    module Verification
+      class MissingHeaderError < StandardError
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller.rb
@@ -10,6 +10,8 @@ module Decidim
 
           layout "decidim/admin/users"
 
+          I18N_SCOPE = "decidim.direct_verifications.verification.admin.direct_verifications"
+
           def index
             enforce_permission_to :index, :authorization
           end
@@ -32,6 +34,9 @@ module Decidim
 
             render(action: :index) && return if show_users_info
 
+            redirect_to direct_verifications_path
+          rescue MissingHeaderError => _e
+            flash[:error] = I18n.t("#{I18N_SCOPE}.create.missing_header")
             redirect_to direct_verifications_path
           end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
                 [%{handler}] (%{count} detected, %{errors} errors)"
               info: "%{count} users detected, of which %{registered} are registered,
                 %{authorized} authorized using [%{handler}] (%{unconfirmed} unconfirmed)"
+              missing_header: Please, provide a header row
               registered: "%{registered} users have been successfully registered (%{count}
                 detected, %{errors} errors) "
               revoked: Verification from %{revoked} users have been revoked using

--- a/spec/commands/decidim/direct_verifications/verification/metadata_parser_spec.rb
+++ b/spec/commands/decidim/direct_verifications/verification/metadata_parser_spec.rb
@@ -6,6 +6,16 @@ module Decidim::DirectVerifications::Verification
   describe MetadataParser do
     subject { described_class.new(txt) }
 
+    describe "#header" do
+      context "when the first line has empty columns" do
+        let(:txt) { "Melina.morrison@bccm.coop,MORRISON Melina,,,11" }
+
+        it "raises an error" do
+          expect { subject.to_h }.to raise_error(MissingHeaderError)
+        end
+      end
+    end
+
     describe "#to_h" do
       context "when the text is empty" do
         let(:txt) { "" }

--- a/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
+++ b/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
@@ -14,6 +14,8 @@ module Decidim::DirectVerifications::Verification::Admin
     let(:verification_type) { "direct_verifications" }
     let(:authorized_user) { create(:user, email: "authorized@example.com", organization: organization) }
 
+    let(:i18n_scope) { "decidim.direct_verifications.verification.admin.direct_verifications" }
+
     before do
       request.env["decidim.current_organization"] = user.organization
       sign_in user, scope: :user
@@ -138,6 +140,24 @@ module Decidim::DirectVerifications::Verification::Admin
 
               user = Decidim::User.find_by(email: "brandy@example.com")
               expect(user.name).to eq("brandy")
+            end
+          end
+
+          context "when the first row has empty columns" do
+            let(:data) { "brandy@example.com,,consumer" }
+
+            it "shows a user error" do
+              post :create, params: { userslist: data, register: true, authorize: "in" }
+              expect(flash[:error]).to eq(I18n.t("#{i18n_scope}.create.missing_header"))
+            end
+          end
+
+          context "when no header is provided" do
+            let(:data) { "brandy@example.com,consumer" }
+
+            it "works" do
+              post :create, params: { userslist: data, register: true, authorize: "in" }
+              expect(response).to redirect_to(direct_verifications_path)
             end
           end
         end

--- a/spec/system/decidim/direct_verifications/admin/direct_verifications_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/direct_verifications_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin creates direct verifications", type: :system do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+  let(:i18n_scope) { "decidim.direct_verifications.verification.admin.direct_verifications" }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+
+    visit decidim_admin_direct_verifications.direct_verifications_path
+  end
+
+  around do |example|
+    original_processor = Rails.configuration.direct_verifications_parser
+    Rails.configuration.direct_verifications_parser = :metadata
+    example.run
+    Rails.configuration.direct_verifications_parser = original_processor
+  end
+
+  context "when registering users" do
+    context "and no header is provided" do
+      it "shows an error message" do
+        fill_in "Emails list", with: "brandy@example.com,,consumer"
+        check "register"
+        choose "authorize_in"
+
+        click_button "Send and process the list"
+
+        expect(page).to have_content(I18n.t("#{i18n_scope}.create.missing_header"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes https://sentry.io/organizations/cercles-coop/issues/2479093815. Note this does not affect CSV uploads.

We infer the user didn't provide a header row (which happens very often) when any of the first row columns are empty. This is a much better UX than silent 500 error. The user will email us at best or simply abandon the job.

![Screenshot from 2021-06-28 13-21-12](https://user-images.githubusercontent.com/762088/123630159-78f27300-d815-11eb-9c44-8750ffd69aa7.png)
