### PR TITLE
Restore multiple verification methods

### DIFF
--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -34,7 +34,7 @@ module Decidim
         attr_reader :form, :file, :organization, :user, :action
 
         def register_users_async
-          RegisterUsersJob.perform_later(file.read, organization, user)
+          RegisterUsersJob.perform_later(file.read, organization, user, form.authorization_handler)
         end
 
         def revoke_users_async

--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -38,7 +38,7 @@ module Decidim
         end
 
         def revoke_users_async
-          RevokeUsersJob.perform_later(file.read, organization, user)
+          RevokeUsersJob.perform_later(file.read, organization, user, form.authorization_handler)
         end
 
         def authorize_users_async

--- a/app/commands/decidim/direct_verifications/verification/create_import.rb
+++ b/app/commands/decidim/direct_verifications/verification/create_import.rb
@@ -42,7 +42,7 @@ module Decidim
         end
 
         def authorize_users_async
-          AuthorizeUsersJob.perform_later(file.read, organization, user)
+          AuthorizeUsersJob.perform_later(file.read, organization, user, form.authorization_handler)
         end
       end
     end

--- a/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
+++ b/app/controllers/decidim/direct_verifications/verification/admin/imports_controller.rb
@@ -6,6 +6,7 @@ module Decidim
       module Admin
         class ImportsController < Decidim::Admin::ApplicationController
           layout "decidim/admin/users"
+          helper_method :workflows, :current_authorization_handler
 
           def new
             enforce_permission_to :create, :authorization
@@ -29,6 +30,23 @@ module Decidim
             end
 
             redirect_to new_import_path
+          end
+
+          def workflows
+            workflows = configured_workflows & current_organization.available_authorizations.map.to_a
+            workflows.map do |workflow|
+              [t("#{workflow}.name", scope: "decidim.authorization_handlers"), workflow]
+            end
+          end
+
+          def configured_workflows
+            return Decidim::DirectVerifications.config.manage_workflows if Decidim::DirectVerifications.config
+
+            ["direct_verifications"]
+          end
+
+          def current_authorization_handler
+            params[:authorization_handler]
           end
         end
       end

--- a/app/forms/decidim/direct_verifications/verification/create_import_form.rb
+++ b/app/forms/decidim/direct_verifications/verification/create_import_form.rb
@@ -15,9 +15,18 @@ module Decidim
         attribute :user, Decidim::User
         attribute :authorize, String
         attribute :register, Boolean
+        attribute :authorization_handler, String
 
-        validates :file, :organization, :user, :authorize, presence: true
+        validates :file, :organization, :user, :authorize, :authorization_handler, presence: true
         validates :authorize, inclusion: { in: ACTIONS.keys }
+
+        validate :available_authorization_handler
+
+        def available_authorization_handler
+          return if authorization_handler.in?(organization.available_authorizations)
+
+          errors.add(:authorization_handler, :inclusion)
+        end
 
         def action
           if register && authorize == "in"

--- a/app/jobs/decidim/direct_verifications/authorize_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/authorize_users_job.rb
@@ -9,7 +9,14 @@ module Decidim
 
       def process_users
         emails.each do |email, data|
-          AuthorizeUser.new(email, data, session, organization, instrumenter).call
+          AuthorizeUser.new(
+            email,
+            data,
+            session,
+            organization,
+            instrumenter,
+            authorization_handler
+          ).call
         end
       end
 

--- a/app/jobs/decidim/direct_verifications/base_import_job.rb
+++ b/app/jobs/decidim/direct_verifications/base_import_job.rb
@@ -10,7 +10,7 @@ module Decidim
     class BaseImportJob < ApplicationJob
       queue_as :default
 
-      def perform(userslist, organization, current_user, authorization_handler = :direct_verifications)
+      def perform(userslist, organization, current_user, authorization_handler)
         @emails = Verification::MetadataParser.new(userslist).to_h
         @organization = organization
         @current_user = current_user

--- a/app/jobs/decidim/direct_verifications/base_import_job.rb
+++ b/app/jobs/decidim/direct_verifications/base_import_job.rb
@@ -10,11 +10,12 @@ module Decidim
     class BaseImportJob < ApplicationJob
       queue_as :default
 
-      def perform(userslist, organization, current_user)
+      def perform(userslist, organization, current_user, authorization_handler = :direct_verifications)
         @emails = Verification::MetadataParser.new(userslist).to_h
         @organization = organization
         @current_user = current_user
         @instrumenter = Instrumenter.new(current_user)
+        @authorization_handler = authorization_handler
 
         process_users
         send_email_notification
@@ -22,10 +23,15 @@ module Decidim
 
       private
 
-      attr_reader :emails, :organization, :current_user, :instrumenter
+      attr_reader :emails, :organization, :current_user, :instrumenter, :authorization_handler
 
       def send_email_notification
-        ImportMailer.finished_processing(current_user, instrumenter, type).deliver_now
+        ImportMailer.finished_processing(
+          current_user,
+          instrumenter,
+          type,
+          authorization_handler
+        ).deliver_now
       end
     end
   end

--- a/app/jobs/decidim/direct_verifications/revoke_users_job.rb
+++ b/app/jobs/decidim/direct_verifications/revoke_users_job.rb
@@ -5,7 +5,7 @@ module Decidim
     class RevokeUsersJob < BaseImportJob
       def process_users
         emails.each do |email, _name|
-          RevokeUser.new(email, organization, instrumenter).call
+          RevokeUser.new(email, organization, instrumenter, authorization_handler).call
         end
       end
 

--- a/app/mailers/decidim/direct_verifications/import_mailer.rb
+++ b/app/mailers/decidim/direct_verifications/import_mailer.rb
@@ -9,10 +9,11 @@ module Decidim
 
       I18N_SCOPE = "decidim.direct_verifications.verification.admin.imports.mailer"
 
-      def finished_processing(user, instrumenter, type)
+      def finished_processing(user, instrumenter, type, handler)
         @stats = Stats.from(instrumenter, type)
         @organization = user.organization
         @i18n_key = "#{I18N_SCOPE}.#{type}"
+        @handler = handler
 
         with_user(user) do
           mail(

--- a/app/views/decidim/direct_verifications/import_mailer/finished_processing.html.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_processing.html.erb
@@ -3,5 +3,5 @@
   count: @stats.count,
   successful: @stats.successful,
   errors: @stats.errors,
-  handler: :direct_verifications
+  handler: @handler
 ) %></p>

--- a/app/views/decidim/direct_verifications/import_mailer/finished_processing.text.erb
+++ b/app/views/decidim/direct_verifications/import_mailer/finished_processing.text.erb
@@ -3,5 +3,5 @@
   count: @stats.count,
   successful: @stats.successful,
   errors: @stats.errors,
-  handler: :direct_verifications
+  handler: @handler
 ) %>

--- a/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
+++ b/app/views/decidim/direct_verifications/verification/admin/imports/new.html.erb
@@ -37,7 +37,8 @@
         <%= t("admin.new.check", scope: "decidim.direct_verifications.verification") %>
       </label>
 
-      <%# TODO: add authorization_handler field %>
+      <%= label_tag :authorization_handler, t("admin.new.authorization_handler", scope: "decidim.direct_verifications.verification") %>
+      <%= select_tag :authorization_handler, options_for_select(workflows, current_authorization_handler) %>
 
       <%= form.file_field :file, label: t(".file") %>
       <%= form.submit t(".submit"), class: "button" %>

--- a/lib/decidim/direct_verifications/authorize_user.rb
+++ b/lib/decidim/direct_verifications/authorize_user.rb
@@ -3,13 +3,16 @@
 module Decidim
   module DirectVerifications
     class AuthorizeUser
-      def initialize(email, data, session, organization, instrumenter)
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(email, data, session, organization, instrumenter, authorization_handler)
         @email = email
         @data = data
         @session = session
         @organization = organization
         @instrumenter = instrumenter
+        @authorization_handler = authorization_handler
       end
+      # rubocop:enable Metrics/ParameterLists
 
       def call
         unless user
@@ -31,7 +34,7 @@ module Decidim
 
       private
 
-      attr_reader :email, :data, :session, :organization, :instrumenter
+      attr_reader :email, :data, :session, :organization, :instrumenter, :authorization_handler
 
       def valid_authorization?
         !authorization.granted? || authorization.expired?
@@ -46,7 +49,7 @@ module Decidim
           begin
             auth = Authorization.find_or_initialize_by(
               user: user,
-              name: :direct_verifications
+              name: authorization_handler
             )
             auth.metadata = data
             auth

--- a/lib/decidim/direct_verifications/revoke_user.rb
+++ b/lib/decidim/direct_verifications/revoke_user.rb
@@ -3,10 +3,11 @@
 module Decidim
   module DirectVerifications
     class RevokeUser
-      def initialize(email, organization, instrumenter)
+      def initialize(email, organization, instrumenter, authorization_handler = :direct_verifications)
         @email = email
         @organization = organization
         @instrumenter = instrumenter
+        @authorization_handler = authorization_handler
       end
 
       def call
@@ -26,14 +27,14 @@ module Decidim
 
       private
 
-      attr_reader :email, :organization, :instrumenter
+      attr_reader :email, :organization, :instrumenter, :authorization_handler
 
       def user
         @user ||= User.find_by(email: email, decidim_organization_id: organization.id)
       end
 
       def authorization
-        @authorization ||= Authorization.find_by(user: user, name: :direct_verifications)
+        @authorization ||= Authorization.find_by(user: user, name: authorization_handler)
       end
 
       def valid_authorization?

--- a/lib/decidim/direct_verifications/revoke_user.rb
+++ b/lib/decidim/direct_verifications/revoke_user.rb
@@ -3,7 +3,7 @@
 module Decidim
   module DirectVerifications
     class RevokeUser
-      def initialize(email, organization, instrumenter, authorization_handler = :direct_verifications)
+      def initialize(email, organization, instrumenter, authorization_handler)
         @email = email
         @organization = organization
         @instrumenter = instrumenter

--- a/lib/decidim/direct_verifications/user_processor.rb
+++ b/lib/decidim/direct_verifications/user_processor.rb
@@ -35,7 +35,7 @@ module Decidim
 
       def revoke_users
         emails.each do |email, _name|
-          RevokeUser.new(email, organization, instrumenter).call
+          RevokeUser.new(email, organization, instrumenter, authorization_handler).call
         end
       end
 

--- a/lib/decidim/direct_verifications/user_processor.rb
+++ b/lib/decidim/direct_verifications/user_processor.rb
@@ -29,7 +29,7 @@ module Decidim
 
       def authorize_users
         emails.each do |email, data|
-          AuthorizeUser.new(email, data, session, organization, instrumenter).call
+          AuthorizeUser.new(email, data, session, organization, instrumenter, authorization_handler).call
         end
       end
 

--- a/spec/commands/decidim/direct_verifications/verification/create_import_spec.rb
+++ b/spec/commands/decidim/direct_verifications/verification/create_import_spec.rb
@@ -9,7 +9,14 @@ module Decidim
         subject(:command) { described_class.new(form) }
 
         let(:form) do
-          instance_double(CreateImportForm, file: file, organization: organization, user: user, action: action)
+          instance_double(
+            CreateImportForm,
+            file: file,
+            organization: organization,
+            user: user,
+            action: action,
+            authorization_handler: "direct_verifications"
+          )
         end
         let(:filename) { file_fixture("users.csv") }
         let(:file) { Rack::Test::UploadedFile.new(filename, "text/csv") }

--- a/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
+++ b/spec/controllers/decidim/direct_verifications/verification/admin/direct_verifications_controller_spec.rb
@@ -163,8 +163,15 @@ module Decidim::DirectVerifications::Verification::Admin
         end
       end
 
-      context "when register users with revoke" do
+      context "when revoking users" do
         params = { userslist: "authorized@example.com", authorize: "out" }
+        it_behaves_like "revoking users", params
+      end
+
+      context "when revoking users with another verification" do
+        params = { userslist: "authorized@example.com", authorize: "out", authorization_handler: "other" }
+        let(:verification_type) { "other" }
+
         it_behaves_like "revoking users", params
       end
     end

--- a/spec/forms/decidim/direct_verifications/verification/create_import_form_spec.rb
+++ b/spec/forms/decidim/direct_verifications/verification/create_import_form_spec.rb
@@ -8,12 +8,14 @@ module Decidim
       describe CreateImportForm do
         subject(:form) { described_class.from_params(attributes) }
 
+        let(:organization) { build(:organization, available_authorizations: %w(direct_verifications)) }
         let(:attributes) do
           {
             user: build(:user),
-            organization: build(:organization),
+            organization: organization,
             file: double(File),
-            authorize: action
+            authorize: action,
+            authorization_handler: "direct_verifications"
           }
         end
         let(:action) { "in" }
@@ -103,6 +105,33 @@ module Decidim
 
             it { is_expected.not_to be_valid }
           end
+        end
+
+        context "when authorization handler is not provided" do
+          let(:attributes) do
+            {
+              user: build(:user),
+              organization: build(:organization),
+              file: double(File),
+              authorize: action
+            }
+          end
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context "when authorization handler is not known" do
+          let(:attributes) do
+            {
+              user: build(:user),
+              organization: build(:organization),
+              file: double(File),
+              authorize: action,
+              authorization_handler: "unknown"
+            }
+          end
+
+          it { is_expected.not_to be_valid }
         end
       end
     end

--- a/spec/jobs/decidim/direct_verifications/register_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/register_users_job_spec.rb
@@ -17,7 +17,7 @@ module Decidim
       before do
         allow(ImportMailer)
           .to receive(:finished_processing)
-          .with(current_user, kind_of(Instrumenter), :registered)
+          .with(current_user, kind_of(Instrumenter), :registered, :direct_verifications)
           .and_return(mailer)
       end
 

--- a/spec/jobs/decidim/direct_verifications/register_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/register_users_job_spec.rb
@@ -17,12 +17,12 @@ module Decidim
       before do
         allow(ImportMailer)
           .to receive(:finished_processing)
-          .with(current_user, kind_of(Instrumenter), :registered, :direct_verifications)
+          .with(current_user, kind_of(Instrumenter), :registered, "direct_verifications")
           .and_return(mailer)
       end
 
       it "creates the user" do
-        expect { described_class.perform_later(userslist, organization, current_user) }
+        expect { described_class.perform_later(userslist, organization, current_user, "direct_verifications") }
           .to change(Decidim::User, :count).from(1).to(2)
 
         user = Decidim::User.find_by(email: "brandy@example.com")
@@ -30,7 +30,7 @@ module Decidim
       end
 
       it "does not authorize the user" do
-        described_class.perform_later(userslist, organization, current_user)
+        described_class.perform_later(userslist, organization, current_user, "direct_verifications")
 
         user = Decidim::User.find_by(email: "brandy@example.com")
         authorization = Decidim::Authorization.find_by(decidim_user_id: user.id)
@@ -38,7 +38,7 @@ module Decidim
       end
 
       it "notifies the result by email" do
-        described_class.perform_later(userslist, organization, current_user)
+        described_class.perform_later(userslist, organization, current_user, "direct_verifications")
         expect(mailer).to have_received(:deliver_now)
       end
     end

--- a/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
@@ -20,7 +20,7 @@ module Decidim
       before do
         allow(ImportMailer)
           .to receive(:finished_processing)
-          .with(current_user, kind_of(Instrumenter), :revoked)
+          .with(current_user, kind_of(Instrumenter), :revoked, :direct_verifications)
           .and_return(mailer)
       end
 

--- a/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
+++ b/spec/jobs/decidim/direct_verifications/revoke_users_job_spec.rb
@@ -20,17 +20,17 @@ module Decidim
       before do
         allow(ImportMailer)
           .to receive(:finished_processing)
-          .with(current_user, kind_of(Instrumenter), :revoked, :direct_verifications)
+          .with(current_user, kind_of(Instrumenter), :revoked, "direct_verifications")
           .and_return(mailer)
       end
 
       it "deletes the user authorization" do
-        described_class.perform_later(userslist, organization, current_user)
+        described_class.perform_later(userslist, organization, current_user, "direct_verifications")
         expect(Decidim::Authorization.find_by(id: authorization.id)).to be_nil
       end
 
       it "notifies the result by email" do
-        described_class.perform_later(userslist, organization, current_user)
+        described_class.perform_later(userslist, organization, current_user, "direct_verifications")
         expect(mailer).to have_received(:deliver_now)
       end
     end

--- a/spec/lib/decidim/direct_verifications/authorize_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/authorize_user_spec.rb
@@ -5,7 +5,11 @@ require "spec_helper"
 module Decidim
   module DirectVerifications
     describe AuthorizeUser do
-      subject { described_class.new(email, data, session, organization, instrumenter) }
+      subject do
+        described_class.new(email, data, session, organization, instrumenter, authorization_handler)
+      end
+
+      let(:authorization_handler) { :direct_verifications }
 
       describe "#call" do
         let(:data) { user.name }

--- a/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
+++ b/spec/lib/decidim/direct_verifications/revoke_user_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 module Decidim
   module DirectVerifications
     describe RevokeUser do
-      subject { described_class.new(email, organization, instrumenter) }
+      subject { described_class.new(email, organization, instrumenter, "direct_verifications") }
 
       let(:user) { create(:user, organization: organization) }
       let(:email) { user.email }
@@ -81,11 +81,11 @@ module Decidim
             allow(authorization).to receive(:destroy!).and_raise(ActiveRecord::ActiveRecordError)
             allow(Authorization)
               .to receive(:find_by)
-              .with(user: user, name: :direct_verifications)
+              .with(user: user, name: "direct_verifications")
               .and_return(authorization)
           end
 
-          it "lets lower-level exceptions to pass through" do
+          it "lets lower-level exceptions pass through" do
             expect { subject.call }.to raise_error(ActiveRecord::ActiveRecordError)
           end
         end

--- a/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
+++ b/spec/mailers/decidim/direct_verifications/import_mailer_spec.rb
@@ -8,10 +8,11 @@ module Decidim
       let(:user) { build(:user) }
 
       describe "#finished_processing" do
-        subject(:mail) { described_class.finished_processing(user, instrumenter, type) }
+        subject(:mail) { described_class.finished_processing(user, instrumenter, type, handler) }
 
         let(:instrumenter) { instance_double(Instrumenter, emails_count: 1, processed_count: 1, errors_count: 0) }
         let(:type) { :registered }
+        let(:handler) { :direct_verifications }
 
         it "sends the email to the passed user" do
           expect(mail.to).to eq([user.email])

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -69,12 +69,21 @@ describe "Admin imports users", type: :system do
       expect(page).to have_current_path(decidim_admin_direct_verifications.new_import_path)
 
       click_link I18n.t("index.authorizations", scope: "decidim.direct_verifications.verification.admin")
-      expect(page).to have_content("Brandy")
+      expect(page).not_to have_content("Brandy") # In the authorizations page we only show those with :direct_verifications
 
       expect(ActionMailer::Base.deliveries.first.to).to contain_exactly("brandy@example.com")
       expect(ActionMailer::Base.deliveries.first.subject).to eq("Invitation instructions")
 
-      expect(ActionMailer::Base.deliveries.last.body.encoded).to include(
+      expect(ActionMailer::Base.deliveries.second.body.encoded).to include(
+        I18n.t(
+          "#{i18n_scope}.imports.mailer.registered",
+          count: 1,
+          successful: 1,
+          errors: 0
+        )
+      )
+
+      expect(ActionMailer::Base.deliveries.third.body.encoded).to include(
         I18n.t(
           "#{i18n_scope}.imports.mailer.authorized",
           handler: :other_verification_method,

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -13,6 +13,12 @@ describe "Admin imports users", type: :system do
     switch_to_host(organization.host)
     login_as user, scope: :user
 
+    organization.available_authorizations = %w(direct_verifications other_verification_method)
+    organization.save!
+    Decidim::DirectVerifications.configure do |config|
+      config.manage_workflows = %w(other_verification_method)
+    end
+
     visit decidim_admin_direct_verifications.new_import_path
   end
 
@@ -87,8 +93,11 @@ describe "Admin imports users", type: :system do
 
     it "revokes users through a CSV file" do
       attach_file("CSV file with users data", filename)
-
       choose(I18n.t("#{i18n_scope}.new.revoke"))
+      select(
+        "translation missing: en.decidim.authorization_handlers.other_verification_method.name",
+        from: "Verification method"
+      )
 
       perform_enqueued_jobs do
         click_button("Upload file")

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -88,7 +88,7 @@ describe "Admin imports users", type: :system do
     end
 
     before do
-      create(:authorization, :granted, user: user_to_revoke, name: :direct_verifications)
+      create(:authorization, :granted, user: user_to_revoke, name: :other_verification_method)
     end
 
     it "revokes users through a CSV file" do
@@ -112,7 +112,7 @@ describe "Admin imports users", type: :system do
       expect(ActionMailer::Base.deliveries.last.body.encoded).to include(
         I18n.t(
           "#{i18n_scope}.imports.mailer.revoked",
-          handler: :direct_verifications,
+          handler: :other_verification_method,
           count: 1,
           successful: 1,
           errors: 0

--- a/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
+++ b/spec/system/decidim/direct_verifications/admin/admin_imports_users_spec.rb
@@ -56,6 +56,10 @@ describe "Admin imports users", type: :system do
 
       check(I18n.t("#{i18n_scope}.new.register"))
       choose(I18n.t("#{i18n_scope}.new.authorize"))
+      select(
+        "translation missing: en.decidim.authorization_handlers.other_verification_method.name",
+        from: "Verification method"
+      )
 
       perform_enqueued_jobs do
         click_button("Upload file")
@@ -73,7 +77,7 @@ describe "Admin imports users", type: :system do
       expect(ActionMailer::Base.deliveries.last.body.encoded).to include(
         I18n.t(
           "#{i18n_scope}.imports.mailer.authorized",
-          handler: :direct_verifications,
+          handler: :other_verification_method,
           count: 1,
           successful: 1,
           errors: 0


### PR DESCRIPTION
This addresses the comments done in https://github.com/Platoniq/decidim-verifications-direct_verifications/pull/28#pullrequestreview-698003747. Essentially, I'm copying the `direct_verifications/index.html.erb` to append that authorization handler field I skipped while developing CSV uploads and passing the param around for `RevokeUser` to use it.

# TODO

- [x] RevokeUser
- [x] AuthorizerUser